### PR TITLE
플레이어가 이동할 수 있는 공간 좌표 생성 알고리즘 구현

### DIFF
--- a/Cybercalypse/Assets/PCG/Prefabs/content.prefab
+++ b/Cybercalypse/Assets/PCG/Prefabs/content.prefab
@@ -1,0 +1,57 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1099794231545662}
+  m_IsPrefabParent: 1
+--- !u!1 &1099794231545662
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4033140592009784}
+  - component: {fileID: 114943804673443378}
+  m_Layer: 0
+  m_Name: content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4033140592009784
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1099794231545662}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114943804673443378
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1099794231545662}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b79bca37846414d47bfd563a6cbbe1a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tileType: 7
+  numOfWidth: 1
+  numOfHeight: 1
+  content: {fileID: 1222385726371932, guid: 153a44f0b861dcb43bfe87a6eb8cd369, type: 2}

--- a/Cybercalypse/Assets/PCG/Prefabs/content.prefab.meta
+++ b/Cybercalypse/Assets/PCG/Prefabs/content.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8784ebe4f8730b4eaa90621e10bd33d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cybercalypse/Assets/PCG/Scenes/PCG Test Scene.unity
+++ b/Cybercalypse/Assets/PCG/Scenes/PCG Test Scene.unity
@@ -140,18 +140,146 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d90fa4f196a4ecd4ba12b0d7cded24ee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  generator: {fileID: 1327378090}
 --- !u!4 &16656405
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 16656403}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 887819893}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &887819892
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 887819893}
+  - component: {fileID: 887819894}
+  m_Layer: 0
+  m_Name: LevelManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &887819893
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 887819892}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 16656405}
+  - {fileID: 1327378091}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &887819894
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 887819892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88290723c2ccb2a41b47da82809972fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1327378089
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1327378091}
+  - component: {fileID: 1327378090}
+  m_Layer: 0
+  m_Name: DungeonGen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1327378090
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1327378089}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 421d82baed2989b4d87f6fd7c65f13ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  contents:
+  - {fileID: 114943804673443378, guid: f8784ebe4f8730b4eaa90621e10bd33d, type: 2}
+  chamberWidth: 5
+  chamberHeight: 5
+  numOfSimulation: 5
+--- !u!4 &1327378091
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1327378089}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 887819893}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1376071644
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1376071646}
+  - component: {fileID: 1376071645}
+  m_Layer: 0
+  m_Name: Test
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1376071645
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1376071644}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 216f5a28d2e865942823806e4086ea65, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1376071646
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1376071644}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1501201749
 GameObject:

--- a/Cybercalypse/Assets/PCG/Scripts/CDungeonGenerator.cs
+++ b/Cybercalypse/Assets/PCG/Scripts/CDungeonGenerator.cs
@@ -11,21 +11,17 @@ public class CDungeonGenerator : AContentsGenerator
     private Dictionary<Vector2Int, CChamber> chamberPosition;
     private Vector2Int startChamberPos, endChamberPos, currentChamberPos;
     // 생성된 게임 오브젝트를 관리하는 Dictionary
-    private Dictionary<Vector2Int, Transform> chamberHolderDict;
+    private Transform spriteHolder;
     // 각 Chamber에 배치된 타일 정보를 저장, 관리하는 Dictionary
-    private Dictionary<Vector2Int, Dictionary<Vector2Int, ETileType>> tileDict;
+    private Dictionary<Vector2Int, ETileType> tileDict;
 
     /// <summary>
     /// 맵 구성요소 생성기 초기화 작업
     /// </summary>
-    private new void Awake()
+    private void Start()
     {
-        base.Awake();
-        tileDict = new Dictionary<Vector2Int, Dictionary<Vector2Int, ETileType>>();
-        chamberPosition = LevelManager.instance.GridGenerator.ChamberPosition;
-        startChamberPos = LevelManager.instance.GridGenerator.StartChamberPos;
-        endChamberPos = LevelManager.instance.GridGenerator.EndChamberPos;
-
+        tileDict = new Dictionary<Vector2Int, ETileType>();
+        spriteHolder = new GameObject("spriteHolder").transform;
     }
 
     /// <summary>
@@ -33,8 +29,17 @@ public class CDungeonGenerator : AContentsGenerator
     /// </summary>
     public override void GenerateContents()
     {
-        currentChamberPos = startChamberPos;
+        // 초기화
+        chamberPosition = LevelManager.instance.GridGenerator.ChamberPosition;
+        startChamberPos = LevelManager.instance.GridGenerator.StartChamberPos;
+        endChamberPos = LevelManager.instance.GridGenerator.EndChamberPos;
 
+        Debug.Log("GenerateContents!");
+        currentChamberPos = startChamberPos;
+        Queue<Vector2Int> startQueue = new Queue<Vector2Int>();
+        startQueue.Enqueue(new Vector2Int(startChamberPos.x * chamberWidth + chamberWidth / 2, startChamberPos.y * chamberHeight + chamberHeight / 2));
+        operateSimulation(startChamberPos, startQueue);
+        //instantiateGameObject();
     }
 
     /// <summary>
@@ -44,42 +49,49 @@ public class CDungeonGenerator : AContentsGenerator
     /// <param name="prevStartQueue">시뮬레이션 할 start 지점 큐</param>
     private void operateSimulation(Vector2Int currentChamberPos, Queue<Vector2Int> prevStartQueue)
     {
-        // 출발할 지점의 큐가 빈 상태면 예외!
+        // 출발할 지점의 큐가 빈 상태면 예외!, StartQueue가 Empty가 되는경우가 언제일까????
         if (prevStartQueue.Count == 0)
         {
+            Debug.Log("nextChamberCount: " + chamberPosition[currentChamberPos].NextChamberPosition.Count);
             Debug.Log("Start Queue is Empty!");
             return;
         }
         // 재귀 메소드가 가지고 있어야 할 정보
-        Dictionary<Vector2Int, ETileType> tilePos = new Dictionary<Vector2Int, ETileType>();
         Queue<Vector2Int> nextStartQueue = new Queue<Vector2Int>();
         int eachNumOfSimulation = numOfSimulation / prevStartQueue.Count;
-
+        
+        Debug.Log("nextChamberCount: " + chamberPosition[currentChamberPos].NextChamberPosition.Count);
         chamberPosition[currentChamberPos].NextChamberPosition.ForEach(delegate (Vector2Int nextChamber)
             {
+                Debug.Log(currentChamberPos + " -> " + nextChamber);
                 // 해당하는 nextChamber가 현재 기준으로 어디 방향인지 검사
                 Vector2Int gap = nextChamber - currentChamberPos;
 
                 // 각 start지점 마다 계산된 횟수만큼 시뮬레이션
                 foreach (Vector2Int start in prevStartQueue)
                 {
-                    tilePos.Add(start, ETileType.Empty);
+                    if (!tileDict.ContainsKey(start))
+                    {
+                        tileDict.Add(start, ETileType.Empty);
+                    }
                     for (int i = 0; i < eachNumOfSimulation; i++)
                     {
-                        simulation(start, nextStartQueue, tilePos, gap);
+                        Debug.Log(i + "th new Simulation");
+                        // 무한 츠쿠요미 ㅠㅠ
+                        simulation(start, currentChamberPos, nextStartQueue, gap);
                     }
                 }
 
-                // nextStartQueue의 y좌표 혹은 x좌표 수정 작업 필요
-                //***
-                // 다음 Chamber를 대상으로 재귀적 수행
-                operateSimulation(nextChamber, nextStartQueue);
+                //다음 Chamber를 대상으로 재귀적 수행
+                if (count < 50)
+                {
+                    count++;
+                    operateSimulation(nextChamber, nextStartQueue);
+                }
+                //operateSimulation(nextChamber, nextStartQueue);
             });
-
-        // 시뮬레이션 된 Dictionary를 tileDict의 해당 위치에 추가
-        tileDict.Add(currentChamberPos, tilePos);
     }
-
+    int count = 0;
     /// <summary>
     /// 시뮬레이션 수행 메소드
     /// </summary>
@@ -87,9 +99,10 @@ public class CDungeonGenerator : AContentsGenerator
     /// <param name="nextStartQueue">다음 시뮬레이션의 출발점 큐</param>
     /// <param name="tilePos">해당 Chamber의 Tile위치를 저장</param>
     /// <param name="gap">어느 방향으로 시뮬레이션 해야 되는지의 기준</param>
-    private void simulation(Vector2Int startPos, Queue<Vector2Int> nextStartQueue, Dictionary<Vector2Int, ETileType> tilePos, Vector2Int gap)
+    private void simulation(Vector2Int startPos, Vector2Int currentChamberPos, Queue<Vector2Int> nextStartQueue, Vector2Int gap)
     {
-        Vector2Int[] adjacentPos = getAdjacentTilePosition(startPos, tilePos, gap);
+        Vector2Int[] adjacentPos = getAdjacentTilePosition(startPos, currentChamberPos, gap);
+
         // 도착점에 도착한 경우 (수정 필요 가능성 존재)
         if(Object.ReferenceEquals(adjacentPos, null))
         {
@@ -98,33 +111,42 @@ public class CDungeonGenerator : AContentsGenerator
         }
 
         int index = (int)Random.Range(0.0f, adjacentPos.Length);
-
-        if (!tilePos.ContainsKey(adjacentPos[index]))
+        if(adjacentPos.Length == 0)
         {
-            tilePos.Add(adjacentPos[index], ETileType.Empty);
+            Debug.Log("Error: " + startPos);
+        }
+        Debug.Log(adjacentPos[index]);
+        if (!tileDict.ContainsKey(adjacentPos[index]))
+        {
+            tileDict.Add(adjacentPos[index], ETileType.Empty);
         }
 
-        simulation(adjacentPos[index], nextStartQueue, tilePos, gap);
+        simulation(adjacentPos[index], currentChamberPos, nextStartQueue, gap);
     }
 
     /// <summary>
     /// start의 인접 좌표 배열을 반환
     /// </summary>
     /// <param name="start"></param>
-    /// <param name="tilePos"></param>
     /// <param name="gap">nextChamberPos - startChamberPos</param>
     /// <returns></returns>
-    private Vector2Int[] getAdjacentTilePosition(Vector2Int start, Dictionary<Vector2Int, ETileType> tilePos, Vector2Int gap)
+    private Vector2Int[] getAdjacentTilePosition(Vector2Int start, Vector2Int currentChamber, Vector2Int gap)
     {
         List<Vector2Int> adjTile = new List<Vector2Int>();
         List<Vector2Int> available = new List<Vector2Int>();
+
+        int xMin = currentChamber.x * chamberWidth;
+        int xMax = (currentChamber.x + 1) * chamberWidth;
+        int yMin = currentChamber.y * chamberHeight;
+        int yMax = (currentChamber.y + 1) * chamberHeight;
 
         // 가는 방향에 확률을 추가하기 위해 밑의 작업을 조금 변형할 수 있음
         if (gap.x != 0)
         {
             if (gap.x == 1)
             {
-                if (start.x == chamberWidth - 1)
+                xMax++;
+                if (start.x == chamberWidth * (currentChamber.x + 1))
                 {
                     return null;
                 }
@@ -133,7 +155,8 @@ public class CDungeonGenerator : AContentsGenerator
             }
             else if (gap.x == -1)
             {
-                if (start.x == 0)
+                xMin--;
+                if (start.x == chamberWidth * currentChamber.x - 1)
                 {
                     return null;
                 }
@@ -148,7 +171,8 @@ public class CDungeonGenerator : AContentsGenerator
         {
             if (gap.y == 1)
             {
-                if (start.y == chamberHeight - 1)
+                yMax++;
+                if (start.y == chamberHeight * (currentChamber.y + 1))
                 {
                     return null;
                 }
@@ -157,7 +181,8 @@ public class CDungeonGenerator : AContentsGenerator
             }
             else if (gap.y == -1)
             {
-                if (start.y == 0)
+                yMin--;
+                if (start.y == chamberHeight * currentChamber.y)
                 {
                     return null;
                 }
@@ -171,12 +196,23 @@ public class CDungeonGenerator : AContentsGenerator
 
         adjTile.ForEach(delegate (Vector2Int adj)
         {
-            if (adj.x >= 0 && adj.x < chamberWidth && adj.y >= 0 && adj.y < chamberHeight)
+            if (adj.x >= xMin && adj.x < xMax && 
+            adj.y >= yMin && adj.y < yMax)
             {
                 available.Add(adj);
             }
         });
 
         return available.ToArray();
+    }
+
+    private void instantiateGameObject()
+    {
+        foreach(KeyValuePair<Vector2Int, ETileType> tile in tileDict)
+        {
+            GameObject tileObject = GameObject.Instantiate(elementDict[ETileType.Empty][0].content, new Vector3(tile.Key.x, tile.Key.y)
+                , Quaternion.identity);
+            tileObject.transform.SetParent(spriteHolder);
+        }
     }
 }

--- a/Cybercalypse/Assets/PCG/Scripts/CGridDrivenContentsGenerator.cs
+++ b/Cybercalypse/Assets/PCG/Scripts/CGridDrivenContentsGenerator.cs
@@ -20,24 +20,23 @@ public class CGridDrivenContentsGenerator : MonoBehaviour
     // 도착 지점의 Chamber 상대 좌표
     public Vector2Int EndChamberPos { get; private set; }
 
-    private AContentsGenerator generator;
+    public AContentsGenerator generator;
 
     void Awake()
     {
         ChamberPosition = new Dictionary<Vector2Int, CChamber>();
     }
-    private void Start()
-    {
-        InitGenerator(10, 10, null);
-        StartGenerator();
-    }
+    //private void Start()
+    //{
+    //    InitGenerator(10, 10, null);
+    //    StartGenerator();
+    //}
 
     /// <summary>
     /// 생성할 맵에 대한 최소 정보 입력(Chamber의 가로 개수, Chamber의 세로 개수, 맵 구성요소 생성기)
     /// </summary>
-    public void InitGenerator(int numOfHorizontal, int numOfVertical, AContentsGenerator _generator)
+    public void InitGenerator(int numOfHorizontal, int numOfVertical)
     {
-        generator = _generator;
         NumOfChamberInHorizontal = numOfHorizontal;
         NumOfChamberInVertical = numOfVertical;
         //makeNoneChamber();
@@ -53,7 +52,7 @@ public class CGridDrivenContentsGenerator : MonoBehaviour
         makeDummyPath(StartChamberPos);
         Debug.Log("Dummy Over");
         // generator를 이용해여 맵 구성요소 생성
-        //generator.GenerateContents();
+        generator.GenerateContents();
     }
 
     /// <summary>

--- a/Cybercalypse/Assets/PCG/Scripts/LevelManager.cs
+++ b/Cybercalypse/Assets/PCG/Scripts/LevelManager.cs
@@ -4,16 +4,12 @@ using UnityEngine;
 
 public class LevelManager : SingleTonManager<LevelManager>
 {
-    public CGraphDrivenContentsGenerator GraphGenerator { get; private set; }
     public CGridDrivenContentsGenerator GridGenerator { get; private set; }
-    public PassageDirectionPool PassageDirectionPool { get; private set; }
 
     new void Awake()
     {
         base.Awake();
 
-        GraphGenerator = new CGraphDrivenContentsGenerator();
-        GridGenerator = new CGridDrivenContentsGenerator();
-        PassageDirectionPool = new PassageDirectionPool();
+        GridGenerator = GetComponentInChildren<CGridDrivenContentsGenerator>();
     }
 }

--- a/Cybercalypse/Assets/PCG/Scripts/TestScript.cs
+++ b/Cybercalypse/Assets/PCG/Scripts/TestScript.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TestScript : MonoBehaviour {
+    private CGridDrivenContentsGenerator generator;
+	// Use this for initialization
+	void Start () {
+        generator = LevelManager.instance.GridGenerator;
+        generator.InitGenerator(10, 10);
+        generator.StartGenerator();
+	}
+}

--- a/Cybercalypse/Assets/PCG/Scripts/TestScript.cs.meta
+++ b/Cybercalypse/Assets/PCG/Scripts/TestScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 216f5a28d2e865942823806e4086ea65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**구현**
- simulation 메소드에서 발생하는 무한 루프 문제 해결
- operateSimulation 메소드 구현
- simulation 메소드 구현 및 에러 수정
- getAdjacentTilePosition 메소드 구현 및 에러 수정

**문제**
- 가상좌표를 생성하기 까지의 시간이 오래걸림
- operateSimulation 메소드에서 prevStartQueue가 비는 경우를 생각해내지 못함
- 실질적으로 눈으로 볼 수 있도록 게임 오브젝트를 생성할 필요가 있음